### PR TITLE
Allow html to be converted to richtext

### DIFF
--- a/lib/HtmlPhpExcel/HtmlPhpExcel.php
+++ b/lib/HtmlPhpExcel/HtmlPhpExcel.php
@@ -212,9 +212,10 @@ class HtmlPhpExcel
                             $this->convertStaticPhpSpreadsheetConstantsFromStringsToConstants($explicitCellType)
                         );
                     } else {
+                        $html = new \PhpOffice\PhpSpreadsheet\Helper\Html();
                         $excelWorksheet->setCellValue(
                             $excelCellIndex,
-                            $this->changeValueEncoding($cell->getValue())
+                            $html->toRichTextObject($this->changeValueEncoding($cell->getValue()))
                         );
                     }
 

--- a/lib/HtmlPhpExcel/Parser/Parser.php
+++ b/lib/HtmlPhpExcel/Parser/Parser.php
@@ -94,6 +94,7 @@ class Parser {
         }
 
         $dom = new \DOMDocument();
+        $this->html = mb_convert_encoding($this->html , 'HTML-ENTITIES', 'UTF-8');
         $dom->loadHTML($this->html);
 
         $xpath = new \DOMXPath($dom);
@@ -148,4 +149,3 @@ class Parser {
         return $document;
     }
 }
-

--- a/lib/HtmlPhpExcel/Parser/Parser.php
+++ b/lib/HtmlPhpExcel/Parser/Parser.php
@@ -117,7 +117,8 @@ class Parser {
 
                 foreach($htmlCells as $htmlCell) {
                     $cell = new Cell();
-                    $cell->setValue($htmlCell->nodeValue);
+                    $value = $htmlCell->ownerDocument->saveXML($htmlCell);
+                    $cell->setValue($value);
 
                     foreach ($htmlCell->attributes as $attribute) {
                         $cell->addAttribute($attribute->name, $attribute->value);


### PR DESCRIPTION
Thanks for the great work for this library.  I needed to be able to convert html code inside the `<td></td>` to rich text for each spreadsheet cell.  Here's the PR that will enable that.  I used the builtin `toRichTextObject` of PHPSpreadsheet to convert html code to richText.

Thanks for considering this.