### PR TITLE
Fix file name length warning

### DIFF
--- a/lib/HtmlPhpExcel/Parser/Parser.php
+++ b/lib/HtmlPhpExcel/Parser/Parser.php
@@ -44,7 +44,7 @@ class Parser {
     public function __construct(string $htmlStringOrFile = null)
     {
         if (null !== $htmlStringOrFile) {
-            if (is_file($htmlStringOrFile)) {
+            if (PHP_MAXPATHLEN >= strlen($htmlStringOrFile) && is_file($htmlStringOrFile)) {
                 $this->setHtmlFile($htmlStringOrFile);
             } elseif (is_string($htmlStringOrFile)) {
                 $this->setHtml($htmlStringOrFile);


### PR DESCRIPTION
In order to fix the " is_file(): File name is longer than the maximum allowed path length on this platform" error that seems prevalent first check if the $htmlStringOrFile satisfies the platform limits on file name lengths.