### PR TITLE
Add attribute for setting cell comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,15 @@ Example:
     </tr>
 </table>
 ```
+
+* `_excel-comment`<br>Adds comment to cell.
+
+Examle:
+```html
+<table>
+    <tr>
+        <td _excel-comment='Comment content'>Cell value</td>
+    </tr>
+</table>
+```
+

--- a/lib/HtmlPhpExcel/HtmlPhpExcel.php
+++ b/lib/HtmlPhpExcel/HtmlPhpExcel.php
@@ -218,6 +218,11 @@ class HtmlPhpExcel
                         );
                     }
 
+                    $cellComment = $cell->getAttribute('_excel-comment');
+                    if ($cellComment) {
+                        $excelWorksheet->getComment($excelCellIndex)->getText()->createText($cellComment);
+                    }
+
                     // Merge cells
                     $colspan = $cell->getAttribute('colspan');
                     $rowspan = $cell->getAttribute('rowspan');


### PR DESCRIPTION
Allow to set comments via `_excel-comment` attribute