### PR TITLE
Reduce Style::applyFromArray() calls for better performance

### DIFF
--- a/lib/HtmlPhpExcel/HtmlPhpExcel.php
+++ b/lib/HtmlPhpExcel/HtmlPhpExcel.php
@@ -189,7 +189,7 @@ class HtmlPhpExcel
                     $excelWorksheet->getStyle($rowNumber.':'.$rowNumber)->applyFromArray($rowStylesArray);
                 }
 
-                $excelWorksheet->getCell('A'.$rowNumber); // Fixes RowIterator exception
+                $excelWorksheet->getCell('A'.$rowNumber);
                 $this->setDimensionsForRow($excelWorksheet, $excelWorksheet->getRowIterator($rowNumber)->current(), $row);
 
                 // Loop over all cells in row

--- a/lib/HtmlPhpExcel/HtmlPhpExcel.php
+++ b/lib/HtmlPhpExcel/HtmlPhpExcel.php
@@ -255,12 +255,7 @@ class HtmlPhpExcel
         if (isset($dimensions['row'])) {
             foreach($dimensions['row'] as $rowKey => $rowValue) {
                 $method = 'set'.ucfirst($rowKey);
-                if ($excelElement instanceof Cell) {
-                    $excelWorksheet->getRowDimension($excelElement->getRow())->$method($rowValue);
-                } elseif ($excelElement instanceof Row) {
-                    $excelWorksheet->getRowDimension($excelElement->getRowIndex())->$method($rowValue);
-                }
-
+                $excelWorksheet->getRowDimension($excelElement->getRowIndex())->$method($rowValue);
             }
         }
     }

--- a/lib/HtmlPhpExcel/HtmlPhpExcel.php
+++ b/lib/HtmlPhpExcel/HtmlPhpExcel.php
@@ -184,8 +184,12 @@ class HtmlPhpExcel
             // Loop over all rows
             $rowNumber = $this->getHighestRow($excelWorksheet);
             foreach($table->getRows() as $row){
+                $rowStylesArray = $this->getRowStylesArray($row);
+                if (!empty($rowStylesArray)) {
+                    $excelWorksheet->getStyle($rowNumber.':'.$rowNumber)->applyFromArray($rowStylesArray);
+                }
 
-                $excelWorksheet->getStyle($rowNumber.':'.$rowNumber)->applyFromArray($this->getRowStylesArray($row));
+                $excelWorksheet->getCell('A'.$rowNumber); // Fixes RowIterator exception
                 $this->setDimensionsForRow($excelWorksheet, $excelWorksheet->getRowIterator($rowNumber)->current(), $row);
 
                 // Loop over all cells in row
@@ -235,7 +239,10 @@ class HtmlPhpExcel
                     }
 
                     // Set styles
-                    $excelWorksheet->getStyle($excelCellIndex)->applyFromArray($this->getCellStylesArray($cell));
+                    $cellStylesArray = $this->getCellStylesArray($cell);
+                    if (!empty($cellStylesArray)) {
+                        $excelWorksheet->getStyle($excelCellIndex)->applyFromArray($cellStylesArray);
+                    }
                     $this->setDimensionsForCell($excelWorksheet, $excelWorksheet->getCell($excelCellIndex), $cell);
 
                     $cellNumber++;


### PR DESCRIPTION
This PR should improve performance of excel file generation by reduction of `Style::applyFromArray()` calls.

For a simple sheet with 16200 rows and 13 columns (not every row has all columns filled) `HtmlPhpExcel::process()` where most of cells hasn't styles execution times are
Before: 12895.6 ms
After:   2532.3 ms

Difference: 10360,3 ms

For smaller sheets difference will be smaller or even not visible. For bigger - can be even better


