### PR TITLE
Ignore invalid _excel-styles

### DIFF
--- a/lib/HtmlPhpExcel/HtmlPhpExcel.php
+++ b/lib/HtmlPhpExcel/HtmlPhpExcel.php
@@ -191,9 +191,9 @@ class HtmlPhpExcel
         $styles = [];
         if ($attributeStyles = $documentElement->getAttribute('_excel-styles')) {
             if (!is_array($attributeStyles)) {
-                $decodedJson = json_decode($attributeStyles, true, 512, JSON_THROW_ON_ERROR);
-                if (null !== $decodedJson) {
-                    $attributeStyles = $decodedJson;
+                try {
+                    $attributeStyles = json_decode($attributeStyles, true, 512, JSON_THROW_ON_ERROR);
+                } catch (\JsonException) {
                 }
             }
         }


### PR DESCRIPTION
This PR reverts behavior from v1 - invalid `_excel-styles` will be ignored.
Now they cause uncaught Exceptions to be thrown